### PR TITLE
Add specific youtube serving domains

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -24,7 +24,9 @@
             "content.js"
         ],
         "matches": [
-            "https://www.youtube.com/*"
+            "https://www.youtube.com/*",
+            "https://www.youtube-nocookie.com/*",
+            "https://www.youtubeeducation.com/*"
         ],
         "run_at": "document_start"
     }],


### PR DESCRIPTION
URL for cookie restriction and for education.
Theses two URL don't redirect to youtube.com